### PR TITLE
Removed SoftMax and added explanation

### DIFF
--- a/02 Training a feed forward network/train.py
+++ b/02 Training a feed forward network/train.py
@@ -27,7 +27,9 @@ class FeedForwardNet(nn.Module):
             nn.ReLU(),
             nn.Linear(256, 10)
         )
-        self.softmax = nn.Softmax(dim=1)
+        # While in the video we apply SoftMax, it's not necessary.
+        # SoftMax is not needed when applying nn.CrossEntropyLoss,
+        # the calculation comes inside already.
 
     def forward(self, input_data):
         x = self.flatten(input_data)

--- a/02 Training a feed forward network/train.py
+++ b/02 Training a feed forward network/train.py
@@ -33,8 +33,7 @@ class FeedForwardNet(nn.Module):
 
     def forward(self, input_data):
         x = self.flatten(input_data)
-        logits = self.dense_layers(x)
-        predictions = self.softmax(logits)
+        predictions = self.dense_layers(x)
         return predictions
 
 


### PR DESCRIPTION
SoftMax is not needed in Pytorch when using CrossEntropyLoss.

https://shaktiwadekar.medium.com/why-softmax-not-used-when-cross-entropy-loss-is-used-as-loss-function-during-neural-network-d77abd708715

https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html#crossentropyloss